### PR TITLE
tutorialに記載のpackage versionを本家のドキュメントと合わせる

### DIFF
--- a/tutorial/tutorial04.md
+++ b/tutorial/tutorial04.md
@@ -17,8 +17,8 @@ keywords = "Flutter,アプリ,チュートリアル,tutorial,入門,外部パッ
       dependencies:
          flutter:
            sdk: flutter
-         cupertino_icons: ^0.1.2
-         english_words: ^3.1.0
+         cupertino_icons: ^0.1.3
+         english_words: ^4.0.0
     {{< /highlight >}}
 
     今回取り込むのは``english_words``というパッケージです。


### PR DESCRIPTION
便利なドキュメントありがとうございます！
packageの記載が本家と異なっていたのでPR作りました。ご確認お願いします。

https://flutter.dev/docs/get-started/codelab#step-2-use-an-external-package